### PR TITLE
CUDA 11 Fix

### DIFF
--- a/nvgpu/__init__.py
+++ b/nvgpu/__init__.py
@@ -12,12 +12,14 @@ def gpu_info():
     lines = _run_cmd(['nvidia-smi'])
     cuda_version = float(lines[2].split('CUDA Version: ')[1].split(' ')[0])
     if cuda_version < 11:
-        selected_lines = lines[7:7 + 3 * gpu_count]
+        line_distance = 3
+        selected_lines = lines[7:7 + line_distance * gpu_count]
     else:
-        selected_lines = lines[8:8 + 4 * gpu_count]
+        line_distance = 4
+        selected_lines = lines[8:8 + line_distance * gpu_count]
     for i in range(gpu_count):
         mem_used, mem_total = [int(m.strip().replace('MiB', '')) for m in
-                               selected_lines[3 * i + 1].split('|')[2].strip().split('/')]
+                               selected_lines[line_distance * i + 1].split('|')[2].strip().split('/')]
         gpu_infos[i]['mem_used'] = mem_used
         gpu_infos[i]['mem_total'] = mem_total
         gpu_infos[i]['mem_used_percent'] = 100. * mem_used / mem_total

--- a/nvgpu/__init__.py
+++ b/nvgpu/__init__.py
@@ -10,7 +10,11 @@ def gpu_info():
     gpu_count = len(gpus)
 
     lines = _run_cmd(['nvidia-smi'])
-    selected_lines = lines[7:7 + 3 * gpu_count]
+    cuda_version = float(lines[2].split('CUDA Version: ')[1].split(' ')[0])
+    if cuda_version < 11:
+        selected_lines = lines[7:7 + 3 * gpu_count]
+    else:
+        selected_lines = lines[8:8 + 4 * gpu_count]
     for i in range(gpu_count):
         mem_used, mem_total = [int(m.strip().replace('MiB', '')) for m in
                                selected_lines[3 * i + 1].split('|')[2].strip().split('/')]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='nvgpu',
-    version='0.8.0',
+    version='0.9.0',
     description='NVIDIA GPU tools',
     url='https://github.com/rossumai/nvgpu',
     author='Bohumir Zamecnik, Rossum',


### PR DESCRIPTION
In CUDA 11, it looks like:

```
Wed Jul 29 21:51:11 2020
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 450.57       Driver Version: 450.57       CUDA Version: 11.0     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  TITAN Xp            On   | 00000000:17:00.0 Off |                  N/A |
| 23%   39C    P8     9W / 250W |      7MiB / 12196MiB |      0%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+
```

I made it compatible with that...