### PR TITLE
Fix error when invoking on MIG enabled gpus

### DIFF
--- a/nvgpu/__init__.py
+++ b/nvgpu/__init__.py
@@ -5,7 +5,8 @@ import subprocess
 
 def gpu_info():
     gpus = [line for line in _run_cmd(['nvidia-smi', '-L']) if line]
-    gpu_infos = [re.match('GPU ([0-9]+): ([^(]+) \(UUID: ([^)]+)\)', gpu).groups() for gpu in gpus]
+    gpu_infos = [re.match('GPU ([0-9]+): ([^(]+) \(UUID: ([^)]+)\)', gpu) for gpu in gpus]
+    gpu_infos = [info.groups() for info in gpu_infos if info is not None]
     gpu_infos = [dict(zip(['index', 'type', 'uuid'], info)) for info in gpu_infos]
     gpu_count = len(gpus)
 

--- a/nvgpu/list_gpus.py
+++ b/nvgpu/list_gpus.py
@@ -20,7 +20,7 @@ def device_status(device_index):
     try:
         utilization = nv.nvmlDeviceGetUtilizationRates(handle).gpu
     except nv.NVMLError:
-        utilization = 'N/A'
+        utilization = None
 
     if six.PY3:
         clock_mhz = nv.nvmlDeviceGetClockInfo(handle, nv.NVML_CLOCK_SM)
@@ -100,7 +100,7 @@ def format_table(df):
             raise ValueError(status)
     df['status'] = df.apply(make_status, axis=1)
     df['color'] = df['status'].apply(color_by_status)
-    df['util.'] = df['utilization'].apply(lambda u: '%03s %%' % u if u != 'N/A' else u)
+    df['util.'] = df['utilization'].apply(lambda u: '%03s %%' % u if u is not None else 'N/A')
     df['MHz'] = df['clock_mhz']
     df['temp.'] = df['temperature']
     df['since'] = df['running_since']


### PR DESCRIPTION
`nvidia-smi -L` output for GPUs that are MIG enabled looks different
which results in some output lines in `gpu_info` to not match. This got
fixed by filtering out None matches.

Additionally `nvidia-smi` and `pynvml` can not get the utilization of a
GPU for which MIG devices are enabled. This results in a 'NVMLError' in
`device_status` which has to be catched. The utilization then is getting
set to 'N/A'.

Sample output from `nvidia-smi -L` on a machine with 4x A100 GPUs which got split into 2x 20GB instances each:

```
GPU 0: A100-SXM4-40GB (UUID: GPU-2ac434d3-1aca-57a0-597d-1d2effdba9f3)
  MIG 3g.20gb Device 0: (UUID: MIG-GPU-2ac434d3-1aca-57a0-597d-1d2effdba9f3/1/0)
  MIG 3g.20gb Device 1: (UUID: MIG-GPU-2ac434d3-1aca-57a0-597d-1d2effdba9f3/2/0)
GPU 1: A100-SXM4-40GB (UUID: GPU-cd9ee947-34d2-d0fe-93e0-2195b3f2fd52)
  MIG 3g.20gb Device 0: (UUID: MIG-GPU-cd9ee947-34d2-d0fe-93e0-2195b3f2fd52/1/0)
  MIG 3g.20gb Device 1: (UUID: MIG-GPU-cd9ee947-34d2-d0fe-93e0-2195b3f2fd52/2/0)
GPU 2: A100-SXM4-40GB (UUID: GPU-67051dc2-cce1-4acf-d254-e76d938eda30)
  MIG 3g.20gb Device 0: (UUID: MIG-GPU-67051dc2-cce1-4acf-d254-e76d938eda30/1/0)
  MIG 3g.20gb Device 1: (UUID: MIG-GPU-67051dc2-cce1-4acf-d254-e76d938eda30/2/0)
GPU 3: A100-SXM4-40GB (UUID: GPU-30f9801c-a554-b6de-bd27-d5cefbf59291)
  MIG 3g.20gb Device 0: (UUID: MIG-GPU-30f9801c-a554-b6de-bd27-d5cefbf59291/1/0)
  MIG 3g.20gb Device 1: (UUID: MIG-GPU-30f9801c-a554-b6de-bd27-d5cefbf59291/2/0)
```