### PR TITLE
Add support for temp, clock and power metrics

### DIFF
--- a/nvgpu/__init__.py
+++ b/nvgpu/__init__.py
@@ -21,9 +21,18 @@ def gpu_info():
     for i in range(gpu_count):
         mem_used, mem_total = [int(m.strip().replace('MiB', '')) for m in
                                selected_lines[line_distance * i + 1].split('|')[2].strip().split('/')]
+        clock, temp, _, pow_used, pow_total = selected_lines[line_distance * i + 1].split('|')[1].split()
         gpu_infos[i]['mem_used'] = mem_used
         gpu_infos[i]['mem_total'] = mem_total
         gpu_infos[i]['mem_used_percent'] = 100. * mem_used / mem_total
+
+        temp = [int(selected_lines[1])]
+        gpu_infos[i]['clock'] = clock
+        gpu_infos[i]['temp'] = temp
+        gpu_infos[i]['pow_used'] = pow_used
+        gpu_infos[i]['pow_total'] = pow_total
+
+
 
     return gpu_infos
 

--- a/nvgpu/__init__.py
+++ b/nvgpu/__init__.py
@@ -22,11 +22,11 @@ def gpu_info():
         mem_used, mem_total = [int(m.strip().replace('MiB', '')) for m in
                                selected_lines[line_distance * i + 1].split('|')[2].strip().split('/')]
         clock, temp, _, pow_used, pow_total = selected_lines[line_distance * i + 1].split('|')[1].split()
+        
         gpu_infos[i]['mem_used'] = mem_used
         gpu_infos[i]['mem_total'] = mem_total
         gpu_infos[i]['mem_used_percent'] = 100. * mem_used / mem_total
 
-        temp = [int(selected_lines[1])]
         gpu_infos[i]['clock'] = clock
         gpu_infos[i]['temp'] = temp
         gpu_infos[i]['pow_used'] = pow_used

--- a/nvgpu/__init__.py
+++ b/nvgpu/__init__.py
@@ -21,18 +21,16 @@ def gpu_info():
     for i in range(gpu_count):
         mem_used, mem_total = [int(m.strip().replace('MiB', '')) for m in
                                selected_lines[line_distance * i + 1].split('|')[2].strip().split('/')]
-        clock, temp, _, pow_used, pow_total = selected_lines[line_distance * i + 1].split('|')[1].split()
+        clock, temp, _, pow_used, _, pow_total = selected_lines[line_distance * i + 1].split('|')[1].split()
+        
         gpu_infos[i]['mem_used'] = mem_used
         gpu_infos[i]['mem_total'] = mem_total
         gpu_infos[i]['mem_used_percent'] = 100. * mem_used / mem_total
 
-        temp = [int(selected_lines[1])]
         gpu_infos[i]['clock'] = clock
         gpu_infos[i]['temp'] = temp
         gpu_infos[i]['pow_used'] = pow_used
         gpu_infos[i]['pow_total'] = pow_total
-
-
 
     return gpu_infos
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(name='nvgpu',
         'tabulate',
     ],
     setup_requires=['setuptools-markdown'],
-    long_description_markdown_filename='README.md',
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         # How mature is this project? Common values are

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
 from setuptools import setup
+import pypandoc
+pypandoc.download_pandoc()
 
 setup(name='nvgpu',
     version='0.9.0',
@@ -24,7 +26,8 @@ setup(name='nvgpu',
         'termcolor',
         'tabulate',
     ],
-    setup_requires=['setuptools-markdown'],
+    setup_requires=['setuptools-markdown', 'pypandoc'],
+    long_description = pypandoc.convert_text('README.md', to='rst', format='md'),
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         # How mature is this project? Common values are


### PR DESCRIPTION
Fixes #20 

How it looks 

```
(nvp) ubuntu@ip-172-31-17-70:~/nvgpu$ python
Python 3.8.15 | packaged by conda-forge | (default, Nov 22 2022, 08:49:35) 
[GCC 10.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import nvgpu
>>> nvgpu.gpu_info()
[{'index': '0', 'type': 'Tesla V100-SXM2-16GB', 'uuid': 'GPU-67292d02-b6e0-e1fe-e3ce-7ceec71a6781', 'mem_used': 0, 'mem_total': 16384, 'mem_used_percent': 0.0, 'clock': 'N/A', 'temp': '25C', 'pow_used': '23W', 'pow_total': '300W'}]
```

I also had a separate issue I needed to fix. The current setup will fail with a pandoc error

To repro

```
cd nvgpu
pip install -e .
```