### PR TITLE
fix: pynvml returns str since 11.5.0

### DIFF
--- a/nvgpu/__init__.py
+++ b/nvgpu/__init__.py
@@ -30,7 +30,7 @@ def gpu_info():
 
 def _run_cmd(cmd):
     output = subprocess.check_output(cmd)
-    if six.PY3:
+    if isinstance(output, bytes):
         output = output.decode('UTF-8')
     return output.split('\n')
 

--- a/nvgpu/list_gpus.py
+++ b/nvgpu/list_gpus.py
@@ -14,7 +14,7 @@ from nvgpu.nvml import nvml_context
 def device_status(device_index):
     handle = nv.nvmlDeviceGetHandleByIndex(device_index)
     device_name = nv.nvmlDeviceGetName(handle)
-    if six.PY3:
+    if isinstance(device_name, bytes):
         device_name = device_name.decode('UTF-8')
     nv_procs = nv.nvmlDeviceGetComputeRunningProcesses(handle)
     try:


### PR DESCRIPTION
fix by checking type return value instead of implicitly via six.PY3